### PR TITLE
Add route layer transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
         <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@0.7.0"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.min.css">
         
-        <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/css/main.css">
-        <script src="https://js.arcgis.com/4.15/"></script>
+        <link rel="stylesheet" href="https://js.arcgis.com/4.16/esri/css/main.css">
+        <script src="https://js.arcgis.com/4.16/"></script>
 
         <link rel="stylesheet" href="css/style.css">
     </head>


### PR DESCRIPTION
Adjust the routes layer transparency to vary based on the number of routes being shown. Removes hard coding of thresholds and uses thresholds based on statistics of routes being shown on map.